### PR TITLE
Fix on_attach callback when using empty config

### DIFF
--- a/lua/yaml-companion/config.lua
+++ b/lua/yaml-companion/config.lua
@@ -33,13 +33,17 @@ M.options = {}
 
 function M.setup(options, on_attach)
   if options == nil then
-    options = { lspconfig = {} }
+    options = {}
   end
 
+  if options.lspconfig == nil then
+    options.lspconfig = {}
+  end
   -- hijack the user supplied on_attach callback to also call our own on_attach
   if options.lspconfig.on_attach then
     options.real_on_attach = options.lspconfig.on_attach
   end
+
   options.lspconfig.on_attach = function(client, bufnr)
     if M.options.real_on_attach then
       M.options.real_on_attach(client, bufnr)


### PR DESCRIPTION
Handle empty configuration blocks as well as empty lspconfig during setup.