### PR TITLE
feat: choose schema with vim.ui.select

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ No mappings included, you need to map it yourself or call it manually:
 :Telescope yaml_schema
 ```
 
+Alternatively, you can use `vim.ui.select` to use the picker of your choice. In that case, you can bind/call the function:
+```lua
+require("yaml-companion").open_ui_select()
+```
+
 ### Get the schema name for the current buffer
 
 You can show the current schema in your statusline using a function like:

--- a/lua/telescope/_extensions/yaml_schema_builtin.lua
+++ b/lua/telescope/_extensions/yaml_schema_builtin.lua
@@ -1,7 +1,6 @@
 local M = {}
 
-local lsp = require("yaml-companion.lsp.requests")
-local matchers = require("yaml-companion._matchers")._loaded
+local lsp = require("yaml-companion.lsp.util")
 local pickers = require("telescope.pickers")
 local finders = require("telescope.finders")
 local conf = require("telescope.config").values
@@ -9,24 +8,10 @@ local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 
 local yaml_schema = function(opts)
-  local results = lsp.get_all_jsonschemas(0)
+  local results = lsp.get_all_yaml_schemas()
+
   if results == nil then
     return
-  end
-
-  -- merge with user defined schemas
-  results = vim.tbl_deep_extend(
-    "force",
-    results.result,
-    require("yaml-companion.config").options.schemas.result or {}
-  )
-
-  -- merge with matchers exposed schemas
-  for _, matcher in pairs(matchers) do
-    local handles = matcher.handles() or {}
-    for _, schema in ipairs(handles) do
-      table.insert(results, schema)
-    end
   end
 
   opts = opts or {}

--- a/lua/yaml-companion/init.lua
+++ b/lua/yaml-companion/init.lua
@@ -30,4 +30,9 @@ M.load_matcher = function(name)
   return _matchers.load(name)
 end
 
+--- Opens a vim.ui.select menu to choose a schema
+M.open_ui_select = function()
+  require("yaml-companion.select.ui").open_ui_select()
+end
+
 return M

--- a/lua/yaml-companion/lsp/util.lua
+++ b/lua/yaml-companion/lsp/util.lua
@@ -1,15 +1,44 @@
 local M = {}
 
-local lsp = vim.lsp
+local nvim_lsp = vim.lsp
+local yaml_lsp = require("yaml-companion.lsp.requests")
+local matchers = require("yaml-companion._matchers")._loaded
 
 -- returns the yamlls client attached to {bufnr} if it has an active yamlls attached
 M.client = function(bufnr)
-  local clients = lsp.buf_get_clients(bufnr)
+  local clients = nvim_lsp.buf_get_clients(bufnr)
   for _, value in pairs(clients) do
     if value.name == "yamlls" then
       return value
     end
   end
+end
+
+--- Get all of the yaml schemas currently available to the server.
+--- @return table schemas: merged list of user-defined and server-provided yaml schemas
+M.get_all_yaml_schemas = function()
+  local schemas = yaml_lsp.get_all_jsonschemas(0)
+
+  if schemas == nil then
+    return
+  end
+
+  -- merge with user defined schemas
+  schemas = vim.tbl_deep_extend(
+    "force",
+    schemas.result,
+    require("yaml-companion.config").options.schemas.result or {}
+  )
+
+  -- merge with matchers exposed schemas
+  for _, matcher in pairs(matchers) do
+    local handles = matcher.handles() or {}
+    for _, schema in ipairs(handles) do
+      table.insert(schemas, schema)
+    end
+  end
+
+  return schemas
 end
 
 return M

--- a/lua/yaml-companion/select/ui.lua
+++ b/lua/yaml-companion/select/ui.lua
@@ -1,0 +1,34 @@
+local M = {}
+
+local lsp = require("yaml-companion.lsp.util")
+local matchers = require("yaml-companion._matchers")._loaded
+
+--- Callback to be passed to vim.ui.select to display a single schema item
+--- @param schema table: Schema
+local display_schema_item = function(schema)
+  return schema.name
+end
+
+--- Callback to be passed to vim.ui.select that changes the active yaml schema
+--- @param schema table: Chosen schema
+local select_schema = function(schema)
+  local selected_schema = { result = { { name = schema.name, uri = schema.uri } } }
+  require("yaml-companion.context").schema(0, selected_schema)
+end
+
+M.open_ui_select = function()
+  local schemas = lsp.get_all_yaml_schemas()
+
+  -- Don't open selection if there are no available schemas
+  if schemas == nil then
+    return
+  end
+
+  vim.ui.select(
+    schemas,
+    { format_item = display_schema_item, prompt = "Schema" },
+    select_schema
+  )
+end
+
+return M

--- a/lua/yaml-companion/select/ui.lua
+++ b/lua/yaml-companion/select/ui.lua
@@ -24,11 +24,7 @@ M.open_ui_select = function()
     return
   end
 
-  vim.ui.select(
-    schemas,
-    { format_item = display_schema_item, prompt = "Schema" },
-    select_schema
-  )
+  vim.ui.select(schemas, { format_item = display_schema_item, prompt = "Schema" }, select_schema)
 end
 
 return M


### PR DESCRIPTION
- add `open_ui_select` function
- move merging predefined and user schema logic to util function so it
  can be used inside both the telescope and vim.ui.select modules

This PR just adds an option for sending schemas to `vim.ui.select` so that people can use whatever frontend they want to display the results.

Feel free to close if this does not match your goals, or comment if you have anything you want to change.

Thanks.