### PR TITLE
Make sure we're talking to the yamlls client

### DIFF
--- a/lua/yaml-companion/lsp/requests.lua
+++ b/lua/yaml-companion/lsp/requests.lua
@@ -3,6 +3,16 @@ local M = {}
 local lsp = vim.lsp
 local sync_timeout = 1000
 
+local function get_yamlls_client(bufnr)
+  local clients = vim.tbl_filter(
+    function(c) return c.name == "yamlls" end,
+    lsp.buf_get_clients(bufnr)
+  )
+  if #clients > 0 then
+    return clients[1]
+  end
+end
+
 -- let the yamlls attached to {bufnr} know that we support
 -- schema selection and it should fire a 'yaml/schema/store/initialized'
 -- when ready to use it
@@ -12,7 +22,7 @@ M.support_schema_selection = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
+  client = client or get_yamlls_client(bufnr)
 
   if client then
     return client.notify("yaml/supportSchemaSelection")
@@ -26,7 +36,7 @@ M.get_all_jsonschemas = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
+  client = client or get_yamlls_client(bufnr)
 
   if client then
     return client.request_sync(
@@ -45,7 +55,7 @@ M.get_jsonschema = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
+  client = client or get_yamlls_client(bufnr)
 
   if client then
     local schemas = client.request_sync(


### PR DESCRIPTION
I don't know if this was true for earlier versions of nvim, but in 0.7 `vim.lsp.get_active_clients()` does not take any args. It just returns the full list of active clients. If `yamlls` is _not_ the first item in that table, these methods are asking some other client for YAML schemas with predictably bad results.