### PR TITLE
Prevent other clients from clobbering context

### DIFF
--- a/lua/yaml-companion/context/init.lua
+++ b/lua/yaml-companion/context/init.lua
@@ -77,6 +77,10 @@ M.autodiscover = function(bufnr, client)
 end
 
 M.setup = function(bufnr, client)
+  if client.name ~= "yamlls" then
+    return
+  end
+
   local state = {
     bufnr = bufnr,
     client = client,


### PR DESCRIPTION
This is related to [the other PR I opened](https://github.com/someone-stole-my-name/yaml-companion.nvim/pull/14) in that it's another case of `yaml-companion` getting stepped on by a different client. In my case I use [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) and when it attaches to a buffer, it replaces the `yamlls` client already stored in context, if one exists.