### PR TITLE
Fix UI no selection and no client

### DIFF
--- a/lua/yaml-companion/context/init.lua
+++ b/lua/yaml-companion/context/init.lua
@@ -44,7 +44,7 @@ M.autodiscover = function(bufnr, client)
 
       -- if it returned something without a name it means it came from our own
       -- internal schema table and we have to loop through it to get the name
-    else
+    elseif options and options.schemas and options.schemas.result then
       for _, option_schema in ipairs(options.schemas.result) do
         if option_schema.uri == schema.result[1].uri then
           M.ctxs[bufnr].schema = {

--- a/lua/yaml-companion/lsp/requests.lua
+++ b/lua/yaml-companion/lsp/requests.lua
@@ -3,6 +3,18 @@ local M = {}
 local lsp = vim.lsp
 local sync_timeout = 1000
 
+-- Get active yamlls client
+---@param bufnr number
+---@return client object
+M.get_client = function(bufnr)
+  local clients = lsp.get_active_clients({ bufnr = bufnr })
+  for _, s_client in pairs(clients) do
+    if s_client.name == "yamlls" then
+      return s_client
+    end
+  end
+end
+
 -- let the yamlls attached to {bufnr} know that we support
 -- schema selection and it should fire a 'yaml/schema/store/initialized'
 -- when ready to use it
@@ -12,7 +24,7 @@ M.support_schema_selection = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
+  client = client or M.get_client(bufnr)
 
   if client then
     return client.notify("yaml/supportSchemaSelection")
@@ -26,8 +38,8 @@ M.get_all_jsonschemas = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
-
+  client = client or M.get_client(bufnr)
+  P(client)
   if client then
     return client.request_sync(
       "yaml/get/all/jsonSchemas",
@@ -45,11 +57,11 @@ M.get_jsonschema = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
+  client = client or M.get_client(bufnr)
 
   if client then
     local schemas =
-      client.request_sync("yaml/get/jsonSchema", vim.uri_from_bufnr(bufnr), sync_timeout, bufnr)
+    client.request_sync("yaml/get/jsonSchema", vim.uri_from_bufnr(bufnr), sync_timeout, bufnr)
     return schemas
   end
 end

--- a/lua/yaml-companion/lsp/requests.lua
+++ b/lua/yaml-companion/lsp/requests.lua
@@ -49,7 +49,7 @@ M.get_jsonschema = function(bufnr, client)
 
   if client then
     local schemas =
-    client.request_sync("yaml/get/jsonSchema", vim.uri_from_bufnr(bufnr), sync_timeout, bufnr)
+      client.request_sync("yaml/get/jsonSchema", vim.uri_from_bufnr(bufnr), sync_timeout, bufnr)
     return schemas
   end
 end

--- a/lua/yaml-companion/lsp/requests.lua
+++ b/lua/yaml-companion/lsp/requests.lua
@@ -3,15 +3,6 @@ local M = {}
 local lsp = vim.lsp
 local sync_timeout = 1000
 
-local function get_yamlls_client(bufnr)
-  local clients = vim.tbl_filter(function(c)
-    return c.name == "yamlls"
-  end, lsp.buf_get_clients(bufnr))
-  if #clients > 0 then
-    return clients[1]
-  end
-end
-
 -- let the yamlls attached to {bufnr} know that we support
 -- schema selection and it should fire a 'yaml/schema/store/initialized'
 -- when ready to use it
@@ -21,7 +12,7 @@ M.support_schema_selection = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or get_yamlls_client(bufnr)
+  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
 
   if client then
     return client.notify("yaml/supportSchemaSelection")
@@ -35,7 +26,8 @@ M.get_all_jsonschemas = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or get_yamlls_client(bufnr)
+  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
+
   if client then
     return client.request_sync(
       "yaml/get/all/jsonSchemas",
@@ -53,7 +45,7 @@ M.get_jsonschema = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or get_yamlls_client(bufnr)
+  client = client or lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
 
   if client then
     local schemas =

--- a/lua/yaml-companion/lsp/requests.lua
+++ b/lua/yaml-companion/lsp/requests.lua
@@ -39,7 +39,6 @@ M.get_all_jsonschemas = function(bufnr, client)
     bufnr = vim.api.nvim_get_current_buf()
   end
   client = client or M.get_client(bufnr)
-  P(client)
   if client then
     return client.request_sync(
       "yaml/get/all/jsonSchemas",

--- a/lua/yaml-companion/lsp/requests.lua
+++ b/lua/yaml-companion/lsp/requests.lua
@@ -3,15 +3,12 @@ local M = {}
 local lsp = vim.lsp
 local sync_timeout = 1000
 
--- Get active yamlls client
----@param bufnr number
----@return client object
-M.get_client = function(bufnr)
-  local clients = lsp.get_active_clients({ bufnr = bufnr })
-  for _, s_client in pairs(clients) do
-    if s_client.name == "yamlls" then
-      return s_client
-    end
+local function get_yamlls_client(bufnr)
+  local clients = vim.tbl_filter(function(c)
+    return c.name == "yamlls"
+  end, lsp.buf_get_clients(bufnr))
+  if #clients > 0 then
+    return clients[1]
   end
 end
 
@@ -24,7 +21,7 @@ M.support_schema_selection = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or M.get_client(bufnr)
+  client = client or get_yamlls_client(bufnr)
 
   if client then
     return client.notify("yaml/supportSchemaSelection")
@@ -38,7 +35,7 @@ M.get_all_jsonschemas = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or M.get_client(bufnr)
+  client = client or get_yamlls_client(bufnr)
   if client then
     return client.request_sync(
       "yaml/get/all/jsonSchemas",
@@ -56,7 +53,7 @@ M.get_jsonschema = function(bufnr, client)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
   end
-  client = client or M.get_client(bufnr)
+  client = client or get_yamlls_client(bufnr)
 
   if client then
     local schemas =

--- a/lua/yaml-companion/lsp/util.lua
+++ b/lua/yaml-companion/lsp/util.lua
@@ -7,8 +7,8 @@ local matchers = require("yaml-companion._matchers")._loaded
 --- @return table schemas: merged list of user-defined, server-provided, and matcher-provided yaml schemas
 M.get_all_yaml_schemas = function()
   local schemas = lsp.get_all_jsonschemas(0)
-
-  if schemas == nil then
+  if schemas == nil or vim.tbl_count(schemas.result or {}) == 0 then
+    vim.notify("Schemas not loaded yet.")
     return
   end
 
@@ -18,6 +18,12 @@ M.get_all_yaml_schemas = function()
     schemas.result,
     require("yaml-companion.config").options.schemas.result or {}
   )
+
+  for i, schema in ipairs(schemas) do
+    if not schema.uri or not schema.uri:find("^https?") then
+      table.remove(schemas, i)
+    end
+  end
 
   -- merge with matchers exposed schemas
   for _, matcher in pairs(matchers) do

--- a/lua/yaml-companion/lsp/util.lua
+++ b/lua/yaml-companion/lsp/util.lua
@@ -19,12 +19,6 @@ M.get_all_yaml_schemas = function()
     require("yaml-companion.config").options.schemas.result or {}
   )
 
-  for i, schema in ipairs(schemas) do
-    if not schema.uri or not schema.uri:find("^https?") then
-      table.remove(schemas, i)
-    end
-  end
-
   -- merge with matchers exposed schemas
   for _, matcher in pairs(matchers) do
     local handles = matcher.handles() or {}

--- a/lua/yaml-companion/select/ui.lua
+++ b/lua/yaml-companion/select/ui.lua
@@ -6,12 +6,15 @@ local matchers = require("yaml-companion._matchers")._loaded
 --- Callback to be passed to vim.ui.select to display a single schema item
 --- @param schema table: Schema
 local display_schema_item = function(schema)
-  return schema.name
+  return schema.name or schema.uri
 end
 
 --- Callback to be passed to vim.ui.select that changes the active yaml schema
 --- @param schema table: Chosen schema
 local select_schema = function(schema)
+  if not schema then
+    return
+  end
   local selected_schema = { result = { { name = schema.name, uri = schema.uri } } }
   require("yaml-companion.context").schema(0, selected_schema)
 end
@@ -24,7 +27,11 @@ M.open_ui_select = function()
     return
   end
 
-  vim.ui.select(schemas, { format_item = display_schema_item, prompt = "Schema" }, select_schema)
+  vim.ui.select(
+    schemas,
+    { format_item = display_schema_item, prompt = "Select YAML Schema" },
+    select_schema
+  )
 end
 
 return M


### PR DESCRIPTION
# Get client
With the previous way of getting the client, this error would prompt:
```
E5108: Error executing lua .../Downloads/nvim-macos/share/nvim/runtime/lua/vim/lsp.lua:1801: attempt to index local 'client' (a nil value)
stack traceback:
        .../Downloads/nvim-macos/share/nvim/runtime/lua/vim/lsp.lua:1801: in function 'get_active_clients'
        .../yaml-companion.nvim/lua/yaml-companion/lsp/requests.lua:29: in function 'get_all_jsonschemas'
        ...tart/yaml-companion.nvim/lua/yaml-companion/lsp/util.lua:9: in function 'get_all_yaml_schemas'
        ...art/yaml-companion.nvim/lua/yaml-companion/select/ui.lua:20: in function 'open_ui_select'
        ...er/start/yaml-companion.nvim/lua/yaml-companion/init.lua:36: in function 'open_ui_select'
        [string ":lua"]:1: in main chunk
```

After the change, this error never pops.
~~(after I finished this PR, I saw that there's another pending PR #14  for the same thing, so I took his code, which looks better than mine, I adopted it, @joshfrench  you are welcome to take the credit for that)~~
**Please merge #14, it's important!**

## To reproduce

Must run REALLY fast:

```
vim foo.yaml
:lua require('yaml-companion').open_ui_select()
```

# UI select no input
If a user clicks escape when the UI select is open, it will prompt an error:

```
E5108: Error executing lua ...art/yaml-companion.nvim/lua/yaml-companion/select/ui.lua:15: attempt to index local 'schema' (a nil value)
stack traceback:
        ...art/yaml-companion.nvim/lua/yaml-companion/select/ui.lua:15: in function 'on_choice'
        ...er/start/dressing.nvim/lua/dressing/select/telescope.lua:117: in function <...er/start/dressing.nvim/lua/dressing/select/telescope.lua:116>
        ...packer/start/telescope.nvim/lua/telescope/actions/mt.lua:75: in function 'key_func'
        ...k/packer/start/telescope.nvim/lua/telescope/mappings.lua:338: in function 'execute_keymap'
        [string ":lua"]:1: in main chunk
```

After the change, this error never pops.

## To reproduce:

```
:lua require('yaml-companion').open_ui_select()
*Press Escape*
```

# Weird "result" entry
For some weird reason, my (latest) yaml-language-server returns a result that looks like this:

```
{
    fromStore = false,
    uri = "result",
    usedForCurrentFile = false
  }
```
So I'm filtering any result that doesn't match `^https?`
![image](https://user-images.githubusercontent.com/17252601/188245387-856ba8b5-1a89-4768-93dd-584c0774fb56.png)
