### PR TITLE
Split schema getters to it's own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,10 @@ use {
 
   -- Additional schemas available in Telescope picker
   schemas = {
-    result = {
-      --{
-      --  name = "Kubernetes 1.22.4",
-      --  uri = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.4-standalone-strict/all.json",
-      --},
-    },
+    --{
+      --name = "Kubernetes 1.22.4",
+      --uri = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.4-standalone-strict/all.json",
+    --},
   },
 
   -- Pass any additional options that will be merged in the final LSP config

--- a/lua/telescope/_extensions/yaml_schema_builtin.lua
+++ b/lua/telescope/_extensions/yaml_schema_builtin.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-local lsp = require("yaml-companion.lsp.util")
 local pickers = require("telescope.pickers")
 local finders = require("telescope.finders")
 local conf = require("telescope.config").values
@@ -8,9 +7,9 @@ local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 
 local yaml_schema = function(opts)
-  local results = lsp.get_all_yaml_schemas()
+  local results = require("yaml-companion.schema").all()
 
-  if results == nil then
+  if #results == 0 then
     return
   end
 
@@ -33,7 +32,7 @@ local yaml_schema = function(opts)
         actions.select_default:replace(function()
           actions.close(prompt_bufnr)
           local selection = action_state.get_selected_entry()
-          local schema = { result = { { name = selection.value.name, uri = selection.value.uri } } }
+          local schema = { name = selection.value.name, uri = selection.value.uri }
           require("yaml-companion.context").schema(0, schema)
         end)
         return true

--- a/lua/yaml-companion/init.lua
+++ b/lua/yaml-companion/init.lua
@@ -15,7 +15,7 @@ end
 
 --- Set the schema used for a buffer.
 ---@param bufnr number: Buffer number
----@param schema SchemaResult
+---@param schema SchemaResult | Schema
 M.set_buf_schema = function(bufnr, schema)
   M.ctx.schema(bufnr, schema)
 end
@@ -23,7 +23,9 @@ end
 --- Get the schema used for a buffer.
 ---@param bufnr number: Buffer number
 M.get_buf_schema = function(bufnr)
-  return M.ctx.schema(bufnr)
+  -- TODO: remove the result and instead return a Schema directly
+  -- this will break existing clients :/
+  return { result = { M.ctx.schema(bufnr) } }
 end
 
 --- Loads a matcher.

--- a/lua/yaml-companion/lsp/util.lua
+++ b/lua/yaml-companion/lsp/util.lua
@@ -2,8 +2,6 @@ local M = {}
 
 local log = require("yaml-companion.log")
 
-local matchers = require("yaml-companion._matchers")._loaded
-
 local sync_timeout = 5000
 
 ---@param bufnr number
@@ -32,33 +30,6 @@ M.request_sync = function(bufnr, method)
 
     return response
   end
-end
-
---- Get all of the yaml schemas currently available to the server.
---- @return SchemaResult | nil schemas: merged list of user-defined, server-provided, and matcher-provided yaml schemas
-M.get_all_yaml_schemas = function()
-  local schemas = require("yaml-companion.lsp.requests").get_all_jsonschemas(0)
-  if schemas == nil or vim.tbl_count(schemas.result or {}) == 0 then
-    vim.notify("Schemas not loaded yet.")
-    return
-  end
-
-  -- merge with user defined schemas
-  schemas = vim.tbl_deep_extend(
-    "force",
-    schemas.result,
-    require("yaml-companion.config").options.schemas.result or {}
-  )
-
-  -- merge with matchers exposed schemas
-  for _, matcher in pairs(matchers) do
-    local handles = matcher.handles() or {}
-    for _, schema in ipairs(handles) do
-      table.insert(schemas, schema)
-    end
-  end
-
-  return schemas
 end
 
 return M

--- a/lua/yaml-companion/schema.lua
+++ b/lua/yaml-companion/schema.lua
@@ -1,0 +1,105 @@
+local M = {}
+
+local options = require("yaml-companion.config").options
+local matchers = require("yaml-companion._matchers")._loaded
+local lsp = require("yaml-companion.lsp.requests")
+
+local log = require("yaml-companion.log")
+
+---@type Schema
+local default_schema = { name = "none", uri = "none" }
+
+---@param schema Schema
+---@return boolean
+local valid_schema = function(schema)
+  if schema and schema.uri then
+    return true
+  end
+  return false
+end
+
+---@return Schema[]
+local options_legacy = function()
+  ---@type Schema[]
+  local r = {}
+  if options and options.schemas and options.schemas.result then
+    for _, schema in ipairs(options.schemas.result) do
+      if valid_schema(schema) then
+        table.insert(r, schema)
+      end
+    end
+  end
+  return r
+end
+
+---@return Schema[]
+local options_new = function()
+  local r = {}
+  if options and options.schemas and not options.schemas.result then
+    for _, schema in ipairs(options.schemas) do
+      if valid_schema(schema) then
+        table.insert(r, schema)
+      end
+    end
+  end
+  return r
+end
+
+---@return Schema
+M.default = function()
+  return default_schema
+end
+
+--- User defined schemas
+---@return Schema[]
+M.from_options = function()
+  local r = options_legacy()
+  if #r > 0 then
+    log.warn(
+      "Using deprecated schemas config ( '{ result = { {}, {} } }' ), please update your config and specify custom schemas as an array"
+    )
+  end
+  r = vim.tbl_extend("keep", r, options_new())
+  return r
+end
+
+--- Matcher defined schemas
+---@return Schema[]
+M.from_matchers = function()
+  ---@type Schema[]
+  local r = {}
+  for _, matcher in pairs(matchers) do
+    r = vim.tbl_extend("keep", r, matcher.handles())
+  end
+  return r
+end
+
+--- Matcher defined schemas
+---@return Schema[]
+M.from_store = function()
+  local schemas = lsp.get_all_jsonschemas(0)
+  if schemas == nil or vim.tbl_count(schemas.result or {}) == 0 then
+    return {}
+  end
+  return schemas.result
+end
+
+---@return Schema[]
+M.all = function()
+  local r = M.from_options()
+  r = vim.tbl_extend("keep", r, M.from_matchers())
+  r = vim.tbl_extend("keep", r, M.from_store())
+  return r
+end
+
+---@return Schema
+---@param bufnr number
+M.current = function(bufnr)
+  local schema = lsp.get_jsonschema(bufnr)
+  if not schema or not schema.result[1] then
+    return default_schema
+  end
+  return schema.result[1]
+end
+
+return M

--- a/lua/yaml-companion/select/ui.lua
+++ b/lua/yaml-companion/select/ui.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local lsp = require("yaml-companion.lsp.util")
-
 --- Callback to be passed to vim.ui.select to display a single schema item
 --- @param schema table: Schema
 local display_schema_item = function(schema)
@@ -14,15 +12,15 @@ local select_schema = function(schema)
   if not schema then
     return
   end
-  local selected_schema = { result = { { name = schema.name, uri = schema.uri } } }
+  local selected_schema = { name = schema.name, uri = schema.uri }
   require("yaml-companion.context").schema(0, selected_schema)
 end
 
 M.open_ui_select = function()
-  local schemas = lsp.get_all_yaml_schemas()
+  local schemas = require("yaml-companion.schema").all()
 
   -- Don't open selection if there are no available schemas
-  if schemas == nil then
+  if #schemas == 0 then
     return
   end
 

--- a/tests/minimal_init.vim
+++ b/tests/minimal_init.vim
@@ -8,7 +8,5 @@ runtime! plugin/nvim-lspconfig.vim
 
 lua << EOF
 require("yaml-companion").load_matcher("dummy")
-local yamlconfig = require("yaml-companion").setup()
-require('lspconfig')['yamlls'].setup(yamlconfig)
 vim.lsp.set_log_level("debug")
 EOF

--- a/tests/schema_spec.lua
+++ b/tests/schema_spec.lua
@@ -1,0 +1,101 @@
+local eq = assert.are.same
+
+local function wait_until(fn)
+  for _ = 1, 10 do
+    vim.wait(900)
+    local r = fn()
+    if r then
+      return true
+    end
+  end
+  vim.api.nvim_err_writeln("wait_until: timeout exceeded")
+  return false
+end
+
+local function buf(input, ft, name)
+  local b = vim.api.nvim_create_buf(false, false)
+  vim.api.nvim_buf_set_name(b, name)
+  vim.api.nvim_buf_set_option(b, "filetype", ft)
+  vim.api.nvim_command("buffer " .. b)
+  vim.api.nvim_buf_set_lines(b, 0, -1, true, vim.split(input, "\n"))
+  return wait_until(function()
+    local clients = vim.lsp.get_active_clients()
+    if #clients > 0 then
+      return true
+    end
+  end)
+end
+
+local function wait_for_schemas()
+  return wait_until(function()
+    local r = require("yaml-companion.schema").all()
+    if r and #r > 1 then
+      return true
+    end
+  end)
+end
+
+describe("user defined schemas:", function()
+  after_each(function()
+    vim.api.nvim_buf_delete(0, { force = true })
+    vim.fn.delete("foo.yaml", "rf")
+    assert(wait_until(function()
+      local clients = vim.lsp.get_active_clients()
+      if #clients == 0 then
+        return true
+      end
+      vim.lsp.stop_client(vim.lsp.get_active_clients(), true)
+    end))
+  end)
+
+  local custom_schema = {
+    name = "Some custom schema",
+    uri = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.5-standalone-strict/all.json",
+  }
+
+  it("options.schemas.result should add the schema to the list (legacy)", function()
+    local expect = custom_schema
+    expect.name = expect.name .. " (legacy)"
+    local result = {}
+
+    local yamlconfig = require("yaml-companion").setup({ schemas = { result = { custom_schema } } })
+    require("lspconfig")["yamlls"].setup(yamlconfig)
+
+    assert(buf("---\nfoo: bar\n", "yaml", "foo.yaml"))
+    assert(wait_for_schemas())
+
+    local all_schemas = require("yaml-companion.schema").all()
+
+    for _, schema in ipairs(all_schemas) do
+      if schema.name == custom_schema.name then
+        result = schema
+        break
+      end
+    end
+
+    eq(expect.uri, result.uri)
+  end)
+
+  it("options.schemas should add the schemas to the list (new)", function()
+    local expect = custom_schema
+    expect.name = expect.name .. " (new)"
+    local result = {}
+
+    local yamlconfig = require("yaml-companion").setup({ schemas = { custom_schema } })
+    require("lspconfig")["yamlls"].setup(yamlconfig)
+
+    assert(buf("---\nfoo: bar\n", "yaml", "foo.yaml"))
+    assert(wait_for_schemas())
+
+    local all_schemas = require("yaml-companion.schema").all()
+
+    for _, schema in ipairs(all_schemas) do
+      if schema.name == custom_schema.name then
+        result = schema
+        break
+      end
+    end
+
+    eq(expect.uri, result.uri)
+  end)
+end)

--- a/tests/yaml-companion_spec.lua
+++ b/tests/yaml-companion_spec.lua
@@ -25,9 +25,12 @@ local function buf(input, ft, name)
 end
 
 describe("schema detection:", function()
+  local yamlconfig = require("yaml-companion").setup()
+  require("lspconfig")["yamlls"].setup(yamlconfig)
+
   it("should detect default schema right after start", function()
     assert(buf("", "yaml", ".gitlab-ci.yml"))
-    local expect = require("yaml-companion.context").default_schema()
+    local expect = { result = { require("yaml-companion.schema").default() } }
     local result = require("yaml-companion").get_buf_schema(0)
     assert.are.same(expect, result)
   end)
@@ -35,9 +38,7 @@ describe("schema detection:", function()
   it("should detect 'gitlab-ci' schema", function()
     wait_until(function()
       local result = require("yaml-companion").get_buf_schema(0)
-      if
-        result.result[1].name ~= require("yaml-companion.context").default_schema().result[1].name
-      then
+      if result.result[1].name ~= require("yaml-companion.schema").default().name then
         return true
       end
     end)
@@ -93,9 +94,7 @@ describe("schema detection:", function()
     }
     wait_until(function()
       local result = require("yaml-companion").get_buf_schema(0)
-      if
-        result.result[1].name ~= require("yaml-companion.context").default_schema().result[1].name
-      then
+      if result.name ~= require("yaml-companion.schema").default().name then
         return true
       end
     end)
@@ -112,9 +111,10 @@ describe("schema detection:", function()
         "foo.yml"
       )
     )
-    local expect = { result = require("yaml-companion.builtin.kubernetes").handles() }
+    local expect = { result = { require("yaml-companion.builtin.kubernetes").handles()[1] } }
     wait_until(function()
       local result = require("yaml-companion").get_buf_schema(0)
+      if result.name ~= require("yaml-companion.schema").default().name then
         return true
       end
     end)
@@ -143,14 +143,12 @@ describe("schema detection:", function()
     vim.api.nvim_buf_delete(0, { force = true })
   end)
 
-  it("should detect dummy using the external dummy matcher", function()
+  it("should detect dummy using dummy matcher", function()
     assert(buf("test: true\n", "yaml", "dummy.yml"))
     local expect = { result = require("yaml-companion._matchers.dummy").handles() }
     wait_until(function()
       local result = require("yaml-companion").get_buf_schema(0)
-      if
-        result.result[1].name ~= require("yaml-companion.context").default_schema().result[1].name
-      then
+      if result.result[1].name ~= require("yaml-companion.schema").default().name then
         return true
       end
     end)


### PR DESCRIPTION
Internal apis using SchemaResult now use Schema[]
External apis still use SchemaResult
Config now accepts Schema[] and prints a warning if using SchemaResult