### PR TITLE
fix: replace deprecated get_active_clients with get_clients

### DIFF
--- a/lua/yaml-companion/lsp/util.lua
+++ b/lua/yaml-companion/lsp/util.lua
@@ -7,7 +7,7 @@ local sync_timeout = 5000
 ---@param bufnr number
 ---@return vim.lsp.client | nil
 M.get_client = function(bufnr)
-  return vim.lsp.get_active_clients({ name = "yamlls", bufnr = bufnr })[1]
+  return vim.lsp.get_clients({ name = "yamlls", bufnr = bufnr })[1]
 end
 
 ---@param bufnr number

--- a/tests/schema_spec.lua
+++ b/tests/schema_spec.lua
@@ -19,7 +19,7 @@ local function buf(input, ft, name)
   vim.api.nvim_command("buffer " .. b)
   vim.api.nvim_buf_set_lines(b, 0, -1, true, vim.split(input, "\n"))
   return wait_until(function()
-    local clients = vim.lsp.get_active_clients()
+    local clients = vim.lsp.get_clients()
     if #clients > 0 then
       return true
     end
@@ -40,11 +40,11 @@ describe("user defined schemas:", function()
     vim.api.nvim_buf_delete(0, { force = true })
     vim.fn.delete("foo.yaml", "rf")
     assert(wait_until(function()
-      local clients = vim.lsp.get_active_clients()
+      local clients = vim.lsp.get_clients()
       if #clients == 0 then
         return true
       end
-      vim.lsp.stop_client(vim.lsp.get_active_clients(), true)
+      vim.lsp.stop_client(vim.lsp.get_clients(), true)
     end))
   end)
 

--- a/tests/yaml-companion_spec.lua
+++ b/tests/yaml-companion_spec.lua
@@ -17,7 +17,7 @@ local function buf(input, ft, name)
   vim.api.nvim_command("buffer " .. b)
   vim.api.nvim_buf_set_lines(b, 0, -1, true, vim.split(input, "\n"))
   return wait_until(function()
-    local clients = vim.lsp.get_active_clients()
+    local clients = vim.lsp.get_clients()
     if #clients > 0 then
       return true
     end


### PR DESCRIPTION
Based on Neovim docs: vim.lsp.get_active_clients() is DEPRECATED in 0.10 instead vim.lsp.get_clients() is used.